### PR TITLE
fix: now editor tests won't be shown in test runner by default

### DIFF
--- a/Assets/Tests/Editor/FastScriptReload.Tests.Editor.asmdef
+++ b/Assets/Tests/Editor/FastScriptReload.Tests.Editor.asmdef
@@ -20,7 +20,9 @@
         "0Harmony.dll"
     ],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
If someone wants to see them, add `"testables": ["com.fastscriptreload"]` to manifest
Adding UNITY_INCLUDE_TESTS constraint to editor test assembly fixed the issue
Noticed it in https://github.com/Syomus/ProceduralToolkit
Fixes #56 