### PR TITLE
Deleted meta for ignored Samples folder

### DIFF
--- a/Assets/Samples~.meta
+++ b/Assets/Samples~.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 2cd9f86f8862bc34a8b918edaa8a473c
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Should fix this warning:
A meta data file (.meta) exists but its folder 'Packages/com.fastscriptreload/Samples~' can't be found, and has been created. Empty directories cannot be stored in version control, so it's assumed that the meta data file is for an empty directory in version control. When moving or deleting folders outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it. UnityEditor.CodeEditorProjectSync:SyncAndOpenSolution ()