### PR TITLE
Watch Only Specified mode

### DIFF
--- a/Assets/Scripts/Editor/FastScriptReloadWelcomeScreen.cs
+++ b/Assets/Scripts/Editor/FastScriptReloadWelcomeScreen.cs
@@ -90,9 +90,15 @@ You can always get back to this screen via:
                 GUILayout.Label("Enabled Features:", screen.LabelStyle);
                 using (LayoutHelper.LabelWidth(350))
                 {
-                    ProductPreferenceBase.RenderGuiAndPersistInput(FastScriptReloadPreference.EnableAutoReloadForChangedFiles);
+                    /// When <see cref="FastScriptReloadPreference.WatchOnlySpecified"/> is enabled, <see cref="FastScriptReloadPreference.EnableAutoReloadForChangedFiles"/> state is handled automatically (disabled when empty file watcher)
+                    using (new EditorGUI.DisabledGroupScope((bool)FastScriptReloadPreference.WatchOnlySpecified.GetEditorPersistedValueOrDefault()))
+                    {
+                        ProductPreferenceBase.RenderGuiAndPersistInput(FastScriptReloadPreference.EnableAutoReloadForChangedFiles);
+                    }
                     RenderSettingsWithCheckLimitationsButton(FastScriptReloadPreference.EnableExperimentalAddedFieldsSupport, true, () => ((FastScriptReloadWelcomeScreen)screen).OpenNewFieldsSection());
-                    RenderSettingsWithCheckLimitationsButton(FastScriptReloadPreference.EnableExperimentalEditorHotReloadSupport, false,  () => ((FastScriptReloadWelcomeScreen)screen).OpenEditorHotReloadSection());
+                    RenderSettingsWithCheckLimitationsButton(FastScriptReloadPreference.EnableExperimentalEditorHotReloadSupport, false, () => ((FastScriptReloadWelcomeScreen)screen).OpenEditorHotReloadSection());
+
+                    ProductPreferenceBase.RenderGuiAndPersistInput(FastScriptReloadPreference.WatchOnlySpecified);
                 }
             }
         );
@@ -769,7 +775,16 @@ includeSubdirectories - whether child directories should be watched as well
         //TODO: potentially that's just a normal settings (also in playmode) - but in playmode user is unlikely to make this many changes
         public static readonly IntProjectEditorPreferenceDefinition TriggerDomainReloadIfOverNDynamicallyLoadedAssembles = new IntProjectEditorPreferenceDefinition(
             "Trigger full domain reload after N hot-reloads (when not in play mode)", "TriggerDomainReloadIfOverNDynamicallyLoadedAssembles", 50);
-        
+
+
+        public static readonly ToggleProjectEditorPreferenceDefinition WatchOnlySpecified = new ToggleProjectEditorPreferenceDefinition(
+            "Watch Only Specified", "WatchOnlySpecified", false);
+
+
+        /// <summary>Used to know when file watchers have changed from project window contextual menu (so when to update file watchers)</summary>
+        public static bool FileWatcherSetupEntriesChanged = false;
+
+
         public static void SetCommonMaterialsShader(ShadersMode newShaderModeValue)
         {
             var rootToolFolder = AssetPathResolver.GetAssetFolderPathRelativeToScript(ScriptableObject.CreateInstance(typeof(FastScriptReloadWelcomeScreen)), 1);

--- a/Assets/Scripts/Editor/NewFields/NewFieldsRendererDefaultEditorPatch.cs
+++ b/Assets/Scripts/Editor/NewFields/NewFieldsRendererDefaultEditorPatch.cs
@@ -28,6 +28,13 @@ namespace FastScriptReload.Editor.NewFields
                 var renderAdditionalFieldsDrawDefaultInspectorPostfix = AccessTools.Method(typeof(NewFieldsRendererDefaultEditorPatch), nameof(DrawDefaultInspector));
                 var customEditorRenderingMethod = AccessTools.Method("UnityEditor.Editor:DrawDefaultInspector");
                 harmony.Patch(customEditorRenderingMethod, postfix: new HarmonyMethod(renderAdditionalFieldsDrawDefaultInspectorPostfix)); 
+
+#if ODIN_INSPECTOR
+                // Odin Inspector support
+                var renderAdditionalFieldsDrawOdinInspectorPostfix = AccessTools.Method(typeof(NewFieldsRendererDefaultEditorPatch), nameof(DrawOdinInspector));
+                var customOdinEditorRenderingMethod = AccessTools.Method("Sirenix.OdinInspector.Editor.OdinEditor:DrawOdinInspector");
+                harmony.Patch(customOdinEditorRenderingMethod, postfix: new HarmonyMethod(renderAdditionalFieldsDrawOdinInspectorPostfix));
+#endif
             }
         }
 


### PR DESCRIPTION
Watch Only Specified mode : file watchers cleared and fast script reload disabled when starting a new editor session + enabling fast script reload only when file watcher is not empty
New MenuItems to add/remove file watcher from project window contextual menu