### PR TITLE
Add nice logging when FSR's Roslyn fails to compile the original source code

### DIFF
--- a/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
+++ b/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
@@ -110,6 +110,18 @@ namespace FastScriptReload.Editor.Compilation
                 return new CompileResult(outLibraryPath, outputMessages, exitCode, compiledAssembly, createSourceCodeCombinedResult.SourceCode, 
                     sourceCodeCombinedFilePath, createInternalVisibleToAsmElapsedMilliseconds);
             }
+            catch (SourceCodeHasErrorsException e)
+            {
+                LoggerScoped.LogError("FSR failed to compile the original source code and has not attempted hot reloading. The compiler found the following errors:"
+                    + Environment.NewLine
+                    + Environment.NewLine
+                    + string.Join(Environment.NewLine, e.ErrorDiagnostics.Select(d => d.ToString())));
+
+                // We don't bother trying to build a broken file, so we don't have an output file here.
+                // It looks like passing null is okay at the callsites.
+                // A small modification has been made to a test to accommodate.
+                throw new HotReloadCompilationException(e.Message, e, null);
+            }
             catch (Exception e)
             {
                 LoggerScoped.LogError($"Compilation error: temporary files were not removed so they can be inspected: " 

--- a/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
+++ b/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
@@ -112,15 +112,9 @@ namespace FastScriptReload.Editor.Compilation
             }
             catch (SourceCodeHasErrorsException e)
             {
-                LoggerScoped.LogError("FSR failed to compile the original source code and has not attempted hot reloading. The compiler found the following errors:"
-                    + Environment.NewLine
-                    + Environment.NewLine
-                    + string.Join(Environment.NewLine, e.ErrorDiagnostics.Select(d => d.ToString())));
-
-                // We don't bother trying to build a broken file, so we don't have an output file here.
-                // It looks like passing null is okay at the callsites.
-                // A small modification has been made to a test to accommodate.
-                throw new HotReloadCompilationException(e.Message, e, null);
+                // FastScriptReloadManager has a special case for reporting SourceCodeHasErrorsException.
+                // Just pass it through.
+                throw e;
             }
             catch (Exception e)
             {

--- a/Assets/Scripts/Editor/Compilation/DynamicCompilationBase.cs
+++ b/Assets/Scripts/Editor/Compilation/DynamicCompilationBase.cs
@@ -360,11 +360,14 @@ namespace FastScriptReload.Editor.Compilation
 
     public class SourceCodeHasErrorsException : Exception
     {
-        public IEnumerable<Diagnostic> ErrorDiagnostics { get; }
-
-        public SourceCodeHasErrorsException(IEnumerable<Diagnostic> errorDiagnostics)
+        public SourceCodeHasErrorsException(IEnumerable<Diagnostic> errorDiagnostics) : base(MakeMessage(errorDiagnostics))
         {
-            ErrorDiagnostics = errorDiagnostics;
         }
+
+        private static string MakeMessage(IEnumerable<Diagnostic> errorDiagnostics)
+            => "Failed to compile the original source code. The compiler found the following errors:"
+            + Environment.NewLine
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, errorDiagnostics.Select(d => d.ToString()));
     }
 }

--- a/Assets/Scripts/Editor/Compilation/DynamicCompilationBase.cs
+++ b/Assets/Scripts/Editor/Compilation/DynamicCompilationBase.cs
@@ -74,11 +74,34 @@ namespace FastScriptReload.Editor.Compilation
         {
             var combinedUsingStatements = new List<string>();
             var typesDefined = new List<string>();
+            var errorDiagnostics = new List<Diagnostic>();
             
             var sourceCodeWithAdjustments = sourceCodeFiles.Select(sourceCodeFile =>
             {
                 var fileCode = File.ReadAllText(sourceCodeFile);
-                var tree = CSharpSyntaxTree.ParseText(fileCode, new CSharpParseOptions(preprocessorSymbols: definedPreprocessorSymbols));
+                var tree = CSharpSyntaxTree.ParseText(fileCode, new CSharpParseOptions(preprocessorSymbols: definedPreprocessorSymbols)).WithFilePath(sourceCodeFile);
+
+                // It's important to check whether the compiler was able to correctly interpret the original code.
+                // When the compiler encounters errors, it actually continues and still produces a tree.
+                // This tree even still roundtrips to the original source code.
+                // However, because the code didn't parse correctly, the tree's structure may be wrong.
+                // If we don't detect this here, FSR continues on obliviously, applying transformations to the broken tree.
+                // This sometimes leads to correctly generated code, because the parts of the tree that FSR cared to look at happened to be correct.
+                // However, this should not be relied upon.
+                // Transformations applied to broken trees lead to weird bugs, e.g. things at wrong nesting levels.
+                // The safest thing is to bail on the whole process.
+                // 
+                // Note that this can happen with valid user code!!!
+                // This can trigger if FSR's compiler version is behind the one needed for language features in the code.
+                // The user may think their code is correct, but the compiler may disagree.
+                // In this scenario, it's particularly important to let the user know that something went wrong.
+                // Otherwise, they may expect valid output, and get nearly valid output from a broken tree.
+                // Trust me, these bugs are quite confusing when first encountered!
+                //
+                // We collect errors from all files instead of bailing immediately, for better reporting in the log message.
+                errorDiagnostics.AddRange(tree.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+                if (errorDiagnostics.Any()) return null; // Skip work once we have errors.
+
                 var root = tree.GetRoot();
                 
                 //WARN: needs to walk before root class name changes, otherwise it'll resolve wrong name
@@ -172,6 +195,8 @@ namespace FastScriptReload.Editor.Compilation
 
                 return root.ToFullString();
             }).ToList();
+
+            if (errorDiagnostics.Any()) throw new SourceCodeHasErrorsException(errorDiagnostics);
 
             var sourceCodeCombinedSb = new StringBuilder();
             sourceCodeCombinedSb.Append(DebuggingInformationComment);
@@ -331,6 +356,16 @@ namespace FastScriptReload.Editor.Compilation
         {
             SourceCode = sourceCode;
             TypeNamesDefinitions = typeNamesDefinitions;
+        }
+    }
+
+    public class SourceCodeHasErrorsException : Exception
+    {
+        public IEnumerable<Diagnostic> ErrorDiagnostics { get; }
+
+        public SourceCodeHasErrorsException(IEnumerable<Diagnostic> errorDiagnostics)
+        {
+            ErrorDiagnostics = errorDiagnostics;
         }
     }
 }

--- a/Assets/Scripts/Editor/FastScriptReloadManager.cs
+++ b/Assets/Scripts/Editor/FastScriptReloadManager.cs
@@ -423,7 +423,7 @@ Workaround will search in all folders (under project root) and will use first fo
                     catch (Exception ex)
                     {
                         if (ex is SourceCodeHasErrorsException e)
-                            LoggerScoped.LogError(e.Message);
+                            LoggerScoped.LogError(e.Message + Environment.NewLine);
                         else
                             LoggerScoped.LogError($"Error when updating files: '{(sourceCodeFilesWithUniqueChangesAwaitingHotReload != null ? string.Join(",", sourceCodeFilesWithUniqueChangesAwaitingHotReload.Select(fn => new FileInfo(fn).Name)) : "unknown")}', {ex}");
                         

--- a/Assets/Scripts/Editor/FastScriptReloadManager.cs
+++ b/Assets/Scripts/Editor/FastScriptReloadManager.cs
@@ -422,7 +422,11 @@ Workaround will search in all folders (under project root) and will use first fo
                     }
                     catch (Exception ex)
                     {
-                        LoggerScoped.LogError($"Error when updating files: '{(sourceCodeFilesWithUniqueChangesAwaitingHotReload != null ? string.Join(",", sourceCodeFilesWithUniqueChangesAwaitingHotReload.Select(fn => new FileInfo(fn).Name)) : "unknown")}', {ex}");
+                        if (ex is SourceCodeHasErrorsException e)
+                            LoggerScoped.LogError(e.Message);
+                        else
+                            LoggerScoped.LogError($"Error when updating files: '{(sourceCodeFilesWithUniqueChangesAwaitingHotReload != null ? string.Join(",", sourceCodeFilesWithUniqueChangesAwaitingHotReload.Select(fn => new FileInfo(fn).Name)) : "unknown")}', {ex}");
+                        
                         changesAwaitingHotReload.ForEach(c =>
                         {
                             c.ErrorOn = DateTime.UtcNow;

--- a/Assets/Tests/Editor/Integration/CodePatterns/CompileWithRedirectTestBase.cs
+++ b/Assets/Tests/Editor/Integration/CodePatterns/CompileWithRedirectTestBase.cs
@@ -46,12 +46,14 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
 
                 afterDetourTest(dynamicallyLoadedAssemblyCompilerResult);
             }
+            catch (SourceCodeHasErrorsException e)
+            {
+                Debug.Log(e.Message);
+            }
             catch (HotReloadCompilationException e)
             {
                 Debug.Log($"Compilation Error: {e.InnerException}");
-
-                // SourceCodeCombinedFileCreated could be null, if original source code fails to compile.
-                if (e.SourceCodeCombinedFileCreated != null) InternalEditorUtility.OpenFileAtLineExternal(e.SourceCodeCombinedFileCreated, 0);
+                InternalEditorUtility.OpenFileAtLineExternal(e.SourceCodeCombinedFileCreated, 0);
             }
             finally
             {

--- a/Assets/Tests/Editor/Integration/CodePatterns/CompileWithRedirectTestBase.cs
+++ b/Assets/Tests/Editor/Integration/CodePatterns/CompileWithRedirectTestBase.cs
@@ -49,7 +49,9 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             catch (HotReloadCompilationException e)
             {
                 Debug.Log($"Compilation Error: {e.InnerException}");
-                InternalEditorUtility.OpenFileAtLineExternal(e.SourceCodeCombinedFileCreated, 0);
+
+                // SourceCodeCombinedFileCreated could be null, if original source code fails to compile.
+                if (e.SourceCodeCombinedFileCreated != null) InternalEditorUtility.OpenFileAtLineExternal(e.SourceCodeCombinedFileCreated, 0);
             }
             finally
             {


### PR DESCRIPTION
This adds checks to catch errors in the user's source code, before any FSR transformations happen.

This fixes #84.

It simply gets the error diagnostics from the tree, and aborts with a custom exception and log message instead of attempting to transform the broken code. The diagnostics get shown in the user facing log message.

It could be argued that invalid source code is an expected case, and shouldn't be handled by exception flow. That would require more disruptive changes, so I think this is probably fine for now.

This is particularly necessary because of FSR's old Roslyn version. Currently, if unsupported language features are used, FSR tries to transform the tree anyway, leading to some very strange buggy behaviour. This PR prevents that. It will instead show the diagnostics to the user, which should give some clue what's going on. Obviously this will be fixed when Roslyn gets updated, but the issue could reoccur in the future when new versions come out.