### PR TITLE
Replace slow AccessTools.TypeByName with a faster version

### DIFF
--- a/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
+++ b/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
@@ -27,6 +27,7 @@ namespace FastScriptReload.Editor.Compilation
 
         private static string ApplicationContentsPath = EditorApplication.applicationContentsPath;
         private static readonly List<string> _createdFilesToCleanUp = new List<string>();
+        private static readonly Dictionary<string, Assembly> _typeNameAssemblyCache = new(16);
 
         static DotnetExeDynamicCompilation()
         {
@@ -157,13 +158,10 @@ You can also:
             try
             {
                 var assembliesForTypesInCombinedFile = createSourceCodeCombinedResult.TypeNamesDefinitions
-                    .Select(t => AccessTools.TypeByName(t))
+                    .Select(GetAssemblyByTypeName)
                     .Where(t => t != null)
-                    .Select(t => t.Assembly)
-                    .GroupBy(a => a)
-                    .Select(g => g.First())
-                    .ToList();
-                
+                    .Distinct();
+
                 foreach (var assemblyForTypesInCombinedFile in assembliesForTypesInCombinedFile)
                 {
                     var createdAssemblyWithInternalsVisibleToNewlyCompiled = AddInternalsVisibleToForAllUserAssembliesPostProcess.CreateAssemblyWithInternalsContentsVisibleTo(
@@ -184,6 +182,22 @@ You can also:
         {
             File.WriteAllText(filePath, contents);
             createdFilesToCleanUp.Add(filePath);
+        }
+
+        private static Assembly GetAssemblyByTypeName(string typeName)
+        {
+            // This cache is barely worth it on my machine - it's ~1ms without, ~0ms with.
+            // However, the number of assemblies to search is technically unbounded
+            //  - so this might be more important for somebody else.
+            if (_typeNameAssemblyCache.TryGetValue(typeName, out var assembly)) return assembly;
+
+            // FSR (via Harmony) originally did this search by enumerating assembly.GetTypes().
+            // I can't see anything in the documentation suggesting the assembly.GetType(typeName) version misses any cases.
+            // It's much faster.
+            assembly = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(asm => asm.GetType(typeName, false) != null);
+
+            if (assembly != null) _typeNameAssemblyCache.Add(typeName, assembly);
+            return assembly;
         }
 
         private static string GenerateCompilerArgsRspFileContents(string outLibraryPath, string sourceCodeCombinedFilePath, string assemblyAttributeFilePath, 


### PR DESCRIPTION
This replaces `AccessTools.TypeByName(name)` in `CreateAssemblyCopiesWithInternalsVisibleTo` with a custom version. `AccessTools` does a complete enumeration of every type in every assembly. We can instead just do `assembly.GetType(name)` for each assembly. I've also added a cache, because the search cost is linear in the number of assemblies.

I was seeing very erratic FSR performance on my machine - 400ms if we're feeling lucky, but spiking to multiple seconds - occasionally 10s+! I don't fully understand why it would be so erratic, but `AccessTools.TypeByName` was the major culprit. It was sometimes taking 900ms per call! This new version takes ~0.5ms per call.

I'm 90% sure that this is functionally equivalent to what was there before, but would appreciate a second pair of eyes to review that.