### PR TITLE
Update DotnetExeCompilator.cs - Duplicate Asm fix

### DIFF
--- a/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
+++ b/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
@@ -218,16 +218,22 @@ You can also:
                 rspContents.AppendLine($"-define:{symbol}");
             }
 
+            Dictionary<string, bool> nameLoaded = new Dictionary<string, bool>();
             foreach (var referenceToAdd in ResolveReferencesToAdd(new List<string>()))
             {
-                if (originalAssemblyPathToAsmWithInternalsVisibleToCompiled.TryGetValue(referenceToAdd, out var asmWithInternalsVisibleTo))
+                string key = Path.GetFileName(referenceToAdd);
+                if (!nameLoaded.ContainsKey(key)) // Avoid duplicates of the same assembly
                 {
-                    //Changed assembly have InternalsVisibleTo added to it to avoid any issues where types are defined internal
-                    rspContents.AppendLine($"-r:\"{asmWithInternalsVisibleTo}\"");
-                }
-                else
-                {
-                    rspContents.AppendLine($"-r:\"{referenceToAdd}\"");
+                    if (originalAssemblyPathToAsmWithInternalsVisibleToCompiled.TryGetValue(referenceToAdd, out var asmWithInternalsVisibleTo))
+                    {
+                        //Changed assembly have InternalsVisibleTo added to it to avoid any issues where types are defined internal
+                        rspContents.AppendLine($"-r:\"{asmWithInternalsVisibleTo}\"");
+                    }
+                    else
+                    {
+                        rspContents.AppendLine($"-r:\"{referenceToAdd}\"");
+                    }
+                    nameLoaded.Add(key, true);
                 }
             }
 


### PR DESCRIPTION
My project has the same DLL in an imported package and from the editor (`System.Windows.Forms.dll`). So the plugin will fail with this error (for any class): 

```
Error when updating files: 'Script.cs', 
System.Exception: Compiler failed to produce the assembly. 
Output: 'error CS1703: Multiple assemblies with equivalent identity have been imported: 
'E:\Unity\Project\Assets\StandaloneFileBrowser\Plugins\System.Windows.Forms.dll' 
and 'C:\Program Files\Unity\Hub\Editor\2022.3.7f1\Editor\Data\MonoBleedingEdge\lib\mono\unityjit-win32\System.Windows.Forms.dll'.
Remove one of the duplicate references.'

```

So this fix add a check that no 2 DLLs with the same file name will be added. 
This solved it for me, and might be useful .