### PR TITLE
Mark generated file as read-only to prevent accidental edit

### DIFF
--- a/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
+++ b/Assets/Scripts/Editor/Compilation/DotnetExeCompilator.cs
@@ -49,6 +49,7 @@ namespace FastScriptReload.Editor.Compilation
                     
                     foreach (var fileToCleanup in _createdFilesToCleanUp)
                     {
+                        new FileInfo(fileToCleanup).IsReadOnly = false;
                         File.Delete(fileToCleanup);
                     }
                     _createdFilesToCleanUp.Clear();
@@ -187,6 +188,7 @@ You can also:
         private static void CreateFileAndTrackAsCleanup(string filePath, string contents, List<string> createdFilesToCleanUp)
         {
             File.WriteAllText(filePath, contents);
+            new FileInfo(filePath).IsReadOnly = true;
             createdFilesToCleanUp.Add(filePath);
         }
 


### PR DESCRIPTION
Hiya, not sure this is something you want but I found myself doing fixes to the generated source (where I'd placed breakpoints) and then saving the generated file and waiting for hot-reload which of course never happens.

So I made a small tweak I'm running locally that will just flag the file as read-only so my IDE alerts me when making changes. Thought I'd offer it up for contribution in case someone else finds it useful. 🤷🏻 

I guess its possible someone might genuinely want to modify the generated file but clearing the read-only flag is easy enough, I think most IDEs ask if you want to do this when editing/saving, ... or this kind of behavior would be a configurable setting.

Take it or leave it. 😄 