### PR TITLE
Exclude DirectWindowsApi on non-Windows Editors (issue-118)

### DIFF
--- a/Assets/Scripts/Editor/FastScriptReloadManager.cs
+++ b/Assets/Scripts/Editor/FastScriptReloadManager.cs
@@ -157,7 +157,7 @@ namespace FastScriptReload.Editor
                     _fileWatchers.Add(fileWatcher);
                     
                     break;
-#if UNITY_2021_1_OR_NEWER
+#if UNITY_2021_1_OR_NEWER && UNITY_EDITOR_WIN
                 case FileWatcherImplementation.DirectWindowsApi: 
                 // On Windows, this is a WindowsFileSystemWatcher.
                 // On other platforms, it's the default Mono implementation.


### PR DESCRIPTION
Fixes #118 

Tested on MacOS 13.4 / Unity 2022.3.21f1