### PR TITLE
Use `global::` namespace qualifier when referring to System namespace

### DIFF
--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/CreateNewFieldInitMethodRewriter.cs
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/CreateNewFieldInitMethodRewriter.cs
@@ -13,7 +13,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
 		private readonly Dictionary<string, List<string>> _typeToNewFieldDeclarations;
 		private static readonly string NewFieldsToCreateValueFnDictionaryFieldName = "__Patched_NewFieldNameToInitialValueFn";
 		private static readonly string NewFieldsToGetTypeFnDictionaryFieldName = "__Patched_NewFieldsToGetTypeFnDictionaryFieldName";
-		private static readonly string DictionaryFullNamespaceTypeName = "System.Collections.Generic.Dictionary";
+		private static readonly string DictionaryFullNamespaceTypeName = "global::System.Collections.Generic.Dictionary";
 
 		public static Dictionary<string, Func<object>> ResolveNewFieldsToCreateValueFn(Type forType)
 		{
@@ -99,7 +99,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
 														SyntaxFactory.Token(SyntaxKind.StringKeyword)),
 													SyntaxFactory.Token(SyntaxKind.CommaToken),
 													SyntaxFactory.GenericName(
-															SyntaxFactory.Identifier("System.Func"))
+															SyntaxFactory.Identifier("global::System.Func"))
 														.WithTypeArgumentList(
 															SyntaxFactory.TypeArgumentList(
 																SyntaxFactory.SingletonSeparatedList<TypeSyntax>(
@@ -124,7 +124,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
 																				SyntaxFactory.Token(SyntaxKind.StringKeyword)),
 																			SyntaxFactory.Token(SyntaxKind.CommaToken),
 																			SyntaxFactory.QualifiedName(
-																				SyntaxFactory.IdentifierName("System"),
+																				SyntaxFactory.IdentifierName("global::System"),
 																				SyntaxFactory.GenericName(
 																						SyntaxFactory.Identifier("Func"))
 																					.WithTypeArgumentList(


### PR DESCRIPTION
Yo 👋🏻 

Got a compilation in a file when hot-reloaded which was in place where `System` is also a local namespace, so compiler couldn't resolve generated reference to `System.Collections` at

```csharp
private static System.Collections.Generic.Dictionary<string, System.Func<object>> __Patched_NewFieldNameToInitialValueFn = new System.Collections.Generic.Dictionary<string, System.Func<object>>
{
};
```

This fix qualifies these 3 references to `System` with `global::` to properly resolve.

#### References
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/namespace-alias-qualifier