### PR TITLE
calls in extension methods to another extension method in same file will be rewritten

### DIFF
--- a/Assets/Documentation~/release-notes.md
+++ b/Assets/Documentation~/release-notes.md
@@ -2,8 +2,9 @@
 - File watching can be done via direct WindowsAPI (contributed by SamPruden)
 - Extended UI to allow for easy choice of file watcher implementation
 - Added partial class rewriting support (contributed by Jlabarca)
+- Calls in extension method to another extension method in same file will be rewritten to use static-call instead of instance call
 
-1.6
+- 1.6
 - Added more Unit Tests to ensure various code patterns can be rewritten correctly
 - Added Watch Only Specific Files and Folders mode (contributed by GhatSmith)
 - Added better Odin support for dynamically added fields (contributed by GhatSmith)

--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/ExtensionMethodsCallingOtherExtensionMethodsInSameFileRewriter.cs
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/ExtensionMethodsCallingOtherExtensionMethodsInSameFileRewriter.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace FastScriptReload.Editor.Compilation.CodeRewriting
+{
+    // When calling other extension methods from same file compilation would fail with 'The call is ambiguous between the following methods or properties' 
+    class ExtensionMethodsCallingOtherExtensionMethodsInSameFileRewriter : FastScriptReloadCodeRewriterBase
+    {
+        private Dictionary<string, Dictionary<string, string>>  _typeNameToDeclaredMethodNameToThisArgName = new Dictionary<string, Dictionary<string, string>>();
+        
+        public ExtensionMethodsCallingOtherExtensionMethodsInSameFileRewriter(bool writeRewriteReasonAsComment)
+            : base(writeRewriteReasonAsComment)
+        {
+	        
+        }
+
+        public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            var classDeclaredMethodNameToThisArgName = new Dictionary<string, string>();
+            _typeNameToDeclaredMethodNameToThisArgName[node.Identifier.Text] = classDeclaredMethodNameToThisArgName;
+            
+            foreach (var methodDeclaration in node.Members
+                         .Where(n => n.Kind() == SyntaxKind.MethodDeclaration)
+                         .Select(n => (MethodDeclarationSyntax)n))
+            {
+                var parameters = methodDeclaration.ParameterList.Parameters;
+                if (parameters.Count > 0 && parameters[0].Modifiers.Any(SyntaxKind.ThisKeyword))
+                {
+                    var thisArgumentName = parameters[0].Identifier.Text;
+                    classDeclaredMethodNameToThisArgName.TryAdd(methodDeclaration.Identifier.Text, thisArgumentName);
+                }
+            }
+            
+            return base.VisitClassDeclaration(node);
+        }
+        
+        public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            // Check if the invocation is an instance method with a member access (e.g., selfName.CallingOtherTest())
+            if (node.Expression is MemberAccessExpressionSyntax memberAccess)
+            {
+                var methodName = memberAccess.Name.Identifier.Text;
+                var instanceArgName = memberAccess.Expression;
+                var className = node.Ancestors().OfType<ClassDeclarationSyntax>().First().Identifier.Text;
+                if (_typeNameToDeclaredMethodNameToThisArgName.TryGetValue(className, out var declaredMethodNameToThisArgName)
+                    && declaredMethodNameToThisArgName.TryGetValue(methodName, out var definedInstanceArgName))
+                {
+                    if (instanceArgName.ToString() == definedInstanceArgName)
+                    {
+                        // Rewrite the invocation to a static method call
+                        var newInvocation = SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(methodName))
+                            .WithArgumentList(
+                                SyntaxFactory.ArgumentList(
+                                    SyntaxFactory.SeparatedList(
+                                        node.ArgumentList.Arguments.Insert(0, SyntaxFactory.Argument(instanceArgName)) // Add instance as first argument
+                                    )
+                                )
+                            ).NormalizeWhitespace();
+                        
+                        return AddRewriteCommentIfNeeded(
+                            newInvocation, 
+                            $"{nameof(ExtensionMethodsCallingOtherExtensionMethodsInSameFileRewriter)}:Replaced extension method call with static call"
+                        );
+                    }
+                }
+            }
+
+            return base.VisitInvocationExpression(node);
+        }
+    }
+}

--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/ExtensionMethodsCallingOtherExtensionMethodsInSameFileRewriter.cs.meta
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/ExtensionMethodsCallingOtherExtensionMethodsInSameFileRewriter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9f739c197f9040efabf7f64461882d7b
+timeCreated: 1727194643

--- a/Assets/Scripts/Editor/Compilation/DynamicCompilationBase.cs
+++ b/Assets/Scripts/Editor/Compilation/DynamicCompilationBase.cs
@@ -199,6 +199,7 @@ namespace FastScriptReload.Editor.Compilation
                 
                 root = new BuilderPatternFunctionsRewriter(DebugWriteRewriteReasonAsComment).Visit(root);
                 root = new RecordeRewriter(DebugWriteRewriteReasonAsComment).Visit(root);
+                root = new ExtensionMethodsCallingOtherExtensionMethodsInSameFileRewriter(DebugWriteRewriteReasonAsComment).Visit(root);
                 
                 //processed as last step to simply rewrite all changes made before
                 if (TryResolveUserDefinedOverridesRoot(tree.FilePath, definedPreprocessorSymbols, out var userDefinedOverridesRoot))


### PR DESCRIPTION
 to use static-call instead of instance call. This will prevent 'ambiguous call' error on compilation

#139 