### PR TITLE
Supporting namespaces in partial classes

### DIFF
--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/PartialTreeProcessor.cs
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/PartialTreeProcessor.cs
@@ -61,7 +61,6 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
                 {
                     var namespaceDeclaration = SyntaxFactory
                         .NamespaceDeclaration(SyntaxFactory.ParseName(namespaceName))
-                        .NormalizeWhitespace()
                         .WithMembers(SyntaxFactory.List(typesInNamespace));
 
                     combinedTypeDeclarations.Add(namespaceDeclaration);
@@ -74,7 +73,8 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
             var newRoot = SyntaxFactory.CompilationUnit()
                     .WithUsings(SyntaxFactory.List(uniqueUsingDirectives))
                     .WithMembers(SyntaxFactory.List(combinedTypeDeclarations))
-                    .WithAdditionalAnnotations(new SyntaxAnnotation("PreprocessorSymbols", string.Join(",", definedPreprocessorSymbols)));
+                    .WithAdditionalAnnotations(new SyntaxAnnotation("PreprocessorSymbols", string.Join(",", definedPreprocessorSymbols)))
+                    .NormalizeWhitespace();
 
             return CSharpSyntaxTree.Create(newRoot, null, tree.FilePath)
                     .AddInternalsVisibleToAttribute();

--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/PartialTreeProcessor.cs
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/PartialTreeProcessor.cs
@@ -32,9 +32,8 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
 
             var combinedTypes = new Dictionary<string, List<TypeDeclarationSyntax>>();
             var combinedUsingDirectives = new HashSet<UsingDirectiveSyntax>();
-            var combinedTypesDefined = new HashSet<string>();
 
-            ProcessTree(tree, combinedTypes, combinedUsingDirectives, combinedTypesDefined);
+            ProcessTree(tree, combinedTypes, combinedUsingDirectives);
 
             const int fileSearchMaxDepth = 5;
             var otherPartialFiles = PartialClassFinder.FindPartialClassFilesInDirectory(tree.FilePath, fileSearchMaxDepth)
@@ -43,7 +42,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
             foreach (var file in otherPartialFiles)
             {
                 var partialTree = CSharpSyntaxTree.ParseText(File.ReadAllText(file), path: file);
-                ProcessTree(partialTree, combinedTypes, combinedUsingDirectives, combinedTypesDefined);
+                ProcessTree(partialTree, combinedTypes, combinedUsingDirectives);
             }
 
             var combinedTypeDeclarations = combinedTypes
@@ -68,8 +67,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
         private static void ProcessTree(
                 SyntaxTree tree,
                 Dictionary<string, List<TypeDeclarationSyntax>> combinedTypes,
-                HashSet<UsingDirectiveSyntax> combinedUsingDirectives,
-                HashSet<string> combinedTypesDefined)
+                HashSet<UsingDirectiveSyntax> combinedUsingDirectives)
         {
             var root = tree.GetCompilationUnitRoot();
 
@@ -78,7 +76,6 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
             foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
             {
                 var fullName = NamespaceHelper.GetFullyQualifiedName(typeDecl);
-                combinedTypesDefined.Add(fullName);
 
                 if (!combinedTypes.TryGetValue(fullName, out var declarations))
                 {

--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/PartialTreeProcessor.cs
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/PartialTreeProcessor.cs
@@ -94,6 +94,11 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
 
             foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
             {
+                if (!typeDecl.Modifiers.Any(SyntaxKind.PublicKeyword))
+                {
+                    continue;
+                }
+
                 var namespaceName = NamespaceHelper.GetNamespaceName(typeDecl);
                 var typeName = typeDecl.Identifier.Text;
 

--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/SyntaxTreeHelpers.cs
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/SyntaxTreeHelpers.cs
@@ -7,7 +7,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
 {
     internal static class NamespaceHelper
     {
-        internal static string GetFullyQualifiedName(TypeDeclarationSyntax typeDeclaration)
+        internal static string GetNamespaceName(TypeDeclarationSyntax typeDeclaration)
         {
             var namespaces = new List<string>();
             var currentNode = typeDeclaration.Parent;
@@ -20,10 +20,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
                 currentNode = currentNode.Parent;
             }
             namespaces.Reverse();
-            var namespaceName = string.Join(".", namespaces);
-            return string.IsNullOrEmpty(namespaceName)
-                    ? typeDeclaration.Identifier.Text
-                    : $"{namespaceName}.{typeDeclaration.Identifier.Text}";
+            return string.Join(".", namespaces);
         }
     }
 

--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/SyntaxTreeMergePartialsExtensions.cs
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/SyntaxTreeMergePartialsExtensions.cs
@@ -10,9 +10,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
                 this IEnumerable<SyntaxTree> trees,
                 IEnumerable<string> definedPreprocessorSymbols)
         {
-            return trees
-                    .Select(tree => PartialTreeProcessor.ProcessPartialTree(tree, definedPreprocessorSymbols))
-                    .ToList();
+            return trees.Select(tree => PartialTreeProcessor.ProcessPartialTree(tree, definedPreprocessorSymbols));
         }
     }
 }

--- a/Assets/Tests/Editor/Integration/CodePatterns/CompileWithRedirectTestBase.cs
+++ b/Assets/Tests/Editor/Integration/CodePatterns/CompileWithRedirectTestBase.cs
@@ -82,8 +82,7 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
         
         protected static string ResolveFullTestFilePath(string relativePath)
         {
-            //TODO: how to resolve test path relative to proj dir for tests??
-            return @$"E:\_src-unity\FastScriptReload\Assets\Tests\{relativePath}";
+            return @$"{Directory.GetCurrentDirectory()}\Assets\Tests\{relativePath}";
         }
 
         public void Setup()

--- a/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
+++ b/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
@@ -234,6 +234,41 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
         }
 
         [UnityTest]
+        public IEnumerator Partials_NoDuplicateUsingsMergeTest()
+        {
+            // Arrange
+            const string partialClass1 = @"
+            using System;
+            namespace TestNamespace
+            {
+                public partial class TestClass { }
+            }";
+
+            const string partialClass2 = @"
+            using System;
+            namespace TestNamespace
+            {
+                public partial class TestClass { }
+            }";
+
+            var trees = CombineTrees(partialClass1, partialClass2);
+
+            // Act
+            var result = trees.MergePartials(new List<string> { "DEBUG", "UNITY_EDITOR" });
+
+            // Assert
+            var combinedTree = result.First();
+            var root = combinedTree.GetCompilationUnitRoot();
+
+            // Test Usings
+            var usingDirectives = root.Usings;
+            Assert.AreEqual(1, usingDirectives.Count, "Should have one using directive");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
+
+            yield return null;
+        }
+
+        [UnityTest]
         public IEnumerator Partials_ClassWithFieldsMergeTest()
         {
             // Arrange
@@ -250,6 +285,7 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             }";
 
             const string partialClass2 = @"
+            using System;
             using System.Collections.Generic;
             namespace TestNamespace
             {

--- a/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
+++ b/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
@@ -61,12 +61,12 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
         [UnityTest]
         public IEnumerator Partials_ClassMergeWithoutNamespaceTest()
         {
+            // Arrange
             const string partialClass1 = @"
             using System;
             public partial class TestClass
             {
                 private int _field1;
-                public void Method1() { }
             }";
 
             const string partialClass2 = @"
@@ -74,12 +74,33 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             public partial class TestClass
             {
                 private int _field2;
-                public void Method2() { }
             }";
 
-            yield return MergeAndTest_CSharpPartialClass(partialClass1, partialClass2, hasNamespace: false);
-        }
+            var trees = CombineTrees(partialClass1, partialClass2);
 
+            // Act
+            var result = trees.MergePartials(new List<string> { "DEBUG", "UNITY_EDITOR" });
+
+            var combinedTree = result.First();
+            var root = combinedTree.GetCompilationUnitRoot();
+
+            // Assert
+            var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+            Assert.AreEqual("TestClass", classDeclaration.Identifier.Text, "Class name should be TestClass");
+
+            // Test Fields
+            var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
+            Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
+
+            // Test Usings
+            var usingDirectives = root.Usings;
+            Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
+                "Should have using System.Collections.Generic");
+
+            yield return null;
+        }
 
         [UnityTest]
         public IEnumerator Partials_StructMergeTest()
@@ -107,7 +128,41 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
                 }
             }";
 
-            yield return MergeAndTest_CSharpPartialStruct(partialStruct1, partialStruct2);
+            var trees = CombineTrees(partialStruct1, partialStruct2);
+
+            // Act
+            var result = trees.MergePartials(new List<string> { "DEBUG", "UNITY_EDITOR" });
+
+            var combinedTree = result.First();
+            var root = combinedTree.GetCompilationUnitRoot();
+
+            // Assert
+            // Test Namespace
+            var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
+            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
+
+            var structDeclaration = root.DescendantNodes().OfType<StructDeclarationSyntax>().First();
+            Assert.AreEqual("TestStruct", structDeclaration.Identifier.Text, "Struct name should be TestStruct");
+
+            // Test Fields
+            var fields = structDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
+            Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
+
+            // Test Methods
+            var methods = structDeclaration.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
+            Assert.AreEqual(2, methods.Count, "Combined class should have two methods");
+            Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method1"), "Combined class should contain Method1");
+            Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method2"), "Combined class should contain Method2");
+
+            // Test Usings
+            var usingDirectives = root.Usings;
+            Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
+                "Should have using System.Collections.Generic");
+
+            yield return null;
         }
 
         [UnityTest]
@@ -139,183 +194,129 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             yield return MergeAndTest_CSharpPartialClass(partialClass1, partialClass2);
         }
 
-        private IEnumerator MergeAndTest_CSharpPartialClass(string partialClass1, string partialClass2,
-            bool hasNamespace = true)
+        private IEnumerator MergeAndTest_CSharpPartialClass(params string[] files)
         {
-            var path1 = Path.Combine(_tempPath, "PartialClass1.cs");
-            var path2 = Path.Combine(_tempPath, "PartialClass2.cs");
-            File.WriteAllText(path1, partialClass1);
-            File.WriteAllText(path2, partialClass2);
+            var trees = CombineTrees(files);
 
-            var tree1 = CSharpSyntaxTree.ParseText(partialClass1, path: path1);
-            var tree2 = CSharpSyntaxTree.ParseText(partialClass2, path: path1);
-            var trees = new List<SyntaxTree>
-            {
-                    tree1, tree2
-            };
-
-            var result = trees.MergePartials(new List<string>
-            {
-                    "DEBUG", "UNITY_EDITOR"
-            });
+            // Act
+            var result = trees.MergePartials(new List<string> { "DEBUG", "UNITY_EDITOR" });
 
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
 
-            if (hasNamespace) {
-                //Test Namespace
-                var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
-                Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
-                Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
-            }
+            // Assert
+            // Test Namespace
+            var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
+            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
 
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
             Assert.AreEqual("TestClass", classDeclaration.Identifier.Text, "Class name should be TestClass");
 
-            //Test Fields
+            // Test Fields
             var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
             Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
 
-            //Test Methods
+            // Test Methods
             var methods = classDeclaration.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
             Assert.AreEqual(2, methods.Count, "Combined class should have two methods");
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method1"), "Combined class should contain Method1");
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method2"), "Combined class should contain Method2");
 
-            //Test Usings
+            // Test Usings
             var usingDirectives = root.Usings;
             Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
-            Assert.IsTrue(usingDirectives.Any(u => u.Name.ToString() == "System"), "Should have using System");
-            Assert.IsTrue(usingDirectives.Any(u => u.Name.ToString() == "System.Collections.Generic"), "Should have using System.Collections.Generic");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
+                "Should have using System.Collections.Generic");
 
             yield return null;
         }
-
-        private IEnumerator MergeAndTest_CSharpPartialStruct(string partialClass1, string partialClass2)
-        {
-            var path1 = Path.Combine(_tempPath, "PartialClass1.cs");
-            var path2 = Path.Combine(_tempPath, "PartialClass2.cs");
-            File.WriteAllText(path1, partialClass1);
-            File.WriteAllText(path2, partialClass2);
-
-            var tree1 = CSharpSyntaxTree.ParseText(partialClass1, path: path1);
-            var tree2 = CSharpSyntaxTree.ParseText(partialClass2, path: path1);
-            var trees = new List<SyntaxTree>
-            {
-                    tree1, tree2
-            };
-
-            var result = trees.MergePartials(new List<string>
-            {
-                    "DEBUG", "UNITY_EDITOR"
-            });
-
-            var combinedTree = result.First();
-            var root = combinedTree.GetCompilationUnitRoot();
-
-            //Test Namespace
-            var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
-            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
-            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
-
-            var structDeclaration = root.DescendantNodes().OfType<StructDeclarationSyntax>().First();
-            Assert.AreEqual("TestStruct", structDeclaration.Identifier.Text, "Struct name should be TestStruct");
-
-            //Test Fields
-            var fields = structDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
-            Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
-
-            //Test Methods
-            var methods = structDeclaration.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
-            Assert.AreEqual(2, methods.Count, "Combined class should have two methods");
-            Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method1"), "Combined class should contain Method1");
-            Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method2"), "Combined class should contain Method2");
-
-            //Test Usings
-            var usingDirectives = root.Usings;
-            Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
-            Assert.IsTrue(usingDirectives.Any(u => u.Name.ToString() == "System"), "Should have using System");
-            Assert.IsTrue(usingDirectives.Any(u => u.Name.ToString() == "System.Collections.Generic"), "Should have using System.Collections.Generic");
-
-            yield return null;
-        }
-
 
         [UnityTest]
         public IEnumerator Partials_ClassWithFieldsMergeTest()
         {
             // Arrange
             const string partialClass1 = @"
-                using System;
-                namespace TestNamespace
+            using System;
+            namespace TestNamespace
+            {
+                public partial class TestClassWithFields
                 {
-                    public partial class TestClassWithFields
-                    {
-                        public int Field1;
-                        private string _privateField1;
-                        protected float ProtectedField1;
-                    }
-                }";
+                    public int Field1;
+                    private string _privateField1;
+                    protected float ProtectedField1;
+                }
+            }";
 
             const string partialClass2 = @"
-                using System.Collections.Generic;
-                namespace TestNamespace
-                {
-                    public partial class TestClassWithFields
-                    {
-                        public List<int> Field2;
-                        private DateTime _privateField2;
-                        protected bool ProtectedField2;
-                    }
-                }";
-
-            var path1 = Path.Combine(_tempPath, "PartialClassWithFields1.cs");
-            var path2 = Path.Combine(_tempPath, "PartialClassWithFields2.cs");
-            File.WriteAllText(path1, partialClass1);
-            File.WriteAllText(path2, partialClass2);
-
-            var tree1 = CSharpSyntaxTree.ParseText(partialClass1, path: path1);
-            var tree2 = CSharpSyntaxTree.ParseText(partialClass2, path: path2);
-            var trees = new List<SyntaxTree>
+            using System.Collections.Generic;
+            namespace TestNamespace
             {
-                    tree1, tree2
-            };
+                public partial class TestClassWithFields
+                {
+                    public List<int> Field2;
+                    private DateTime _privateField2;
+                    protected bool ProtectedField2;
+                }
+            }";
+
+            var trees = CombineTrees(partialClass1, partialClass2);
 
             // Act
-            var result = trees.MergePartials(new List<string>
-            {
-                    "DEBUG", "UNITY_EDITOR"
-            });
+            var result = trees.MergePartials(new List<string> { "DEBUG", "UNITY_EDITOR" });
 
             // Assert
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
 
-            //Test Namespace
+            // Test Namespace
             var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
             Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
             Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
 
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
-            Assert.AreEqual("TestClassWithFields", classDeclaration.Identifier.Text, "Class name should be TestClassWithFields");
+            Assert.AreEqual("TestClassWithFields", classDeclaration.Identifier.Text,
+                "Class name should be TestClassWithFields");
 
             // Test Fields
             var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
             Assert.AreEqual(6, fields.Count, "Combined class should have six fields");
 
             // Test specific fields
-            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "Field1" && f.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)))), "Should have public Field1");
-            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "_privateField1" && f.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword)))), "Should have private _privateField1");
-            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "ProtectedField1" && f.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)))), "Should have protected ProtectedField1");
-            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "Field2" && f.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)))), "Should have public Field2");
-            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "_privateField2" && f.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword)))), "Should have private _privateField2");
-            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "ProtectedField2" && f.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)))), "Should have protected ProtectedField2");
+            Assert.IsTrue(
+                fields.Any(f => f.Declaration.Variables.Any(v =>
+                    v.Identifier.Text == "Field1" && f.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)))),
+                "Should have public Field1");
+            Assert.IsTrue(
+                fields.Any(f => f.Declaration.Variables.Any(v =>
+                    v.Identifier.Text == "_privateField1" &&
+                    f.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword)))), "Should have private _privateField1");
+            Assert.IsTrue(
+                fields.Any(f => f.Declaration.Variables.Any(v =>
+                    v.Identifier.Text == "ProtectedField1" &&
+                    f.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)))),
+                "Should have protected ProtectedField1");
+            Assert.IsTrue(
+                fields.Any(f => f.Declaration.Variables.Any(v =>
+                    v.Identifier.Text == "Field2" && f.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)))),
+                "Should have public Field2");
+            Assert.IsTrue(
+                fields.Any(f => f.Declaration.Variables.Any(v =>
+                    v.Identifier.Text == "_privateField2" &&
+                    f.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword)))), "Should have private _privateField2");
+            Assert.IsTrue(
+                fields.Any(f => f.Declaration.Variables.Any(v =>
+                    v.Identifier.Text == "ProtectedField2" &&
+                    f.Modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword)))),
+                "Should have protected ProtectedField2");
 
             // Test Usings
             var usingDirectives = root.Usings;
             Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
-            Assert.IsTrue(usingDirectives.Any(u => u.Name.ToString() == "System"), "Should have using System");
-            Assert.IsTrue(usingDirectives.Any(u => u.Name.ToString() == "System.Collections.Generic"), "Should have using System.Collections.Generic");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
+                "Should have using System.Collections.Generic");
 
             yield return null;
         }
@@ -342,11 +343,7 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
                 }
             }";
 
-            var path = Path.Combine(_tempPath, "SameFilePartials.cs");
-            File.WriteAllText(path, sameFilePartials);
-
-            var tree = CSharpSyntaxTree.ParseText(sameFilePartials, path: path);
-            var trees = new List<SyntaxTree> { tree };
+            var trees = CombineTrees(sameFilePartials);
 
             // Act
             var result = trees.MergePartials(new List<string> { "DEBUG", "UNITY_EDITOR" });
@@ -355,7 +352,7 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
 
-            //Test Namespace
+            // Test Namespace
             var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
             Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
             Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
@@ -366,8 +363,10 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             // Test Fields
             var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
             Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
-            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "_field1")), "Should have _field1");
-            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "_field2")), "Should have _field2");
+            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "_field1")),
+                "Should have _field1");
+            Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "_field2")),
+                "Should have _field2");
 
             // Test Methods
             var methods = classDeclaration.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
@@ -378,8 +377,9 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             // Test Usings
             var usingDirectives = root.Usings;
             Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
-            Assert.IsTrue(usingDirectives.Any(u => u.Name.ToString() == "System"), "Should have using System");
-            Assert.IsTrue(usingDirectives.Any(u => u.Name.ToString() == "System.Collections.Generic"), "Should have using System.Collections.Generic");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
+            Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
+                "Should have using System.Collections.Generic");
 
             // Test that there's only one class declaration
             var classDeclarations = root.DescendantNodes().OfType<ClassDeclarationSyntax>().ToList();
@@ -422,17 +422,7 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
                 }
             }";
 
-            var path1 = Path.Combine(_tempPath, "PartialClass1.cs");
-            var path2 = Path.Combine(_tempPath, "PartialClass2.cs");
-            File.WriteAllText(path1, partialClass1);
-            File.WriteAllText(path2, partialClass2);
-
-            var tree1 = CSharpSyntaxTree.ParseText(partialClass1, path: path1);
-            var tree2 = CSharpSyntaxTree.ParseText(partialClass2, path: path1);
-            var trees = new List<SyntaxTree>
-            {
-                tree1, tree2
-            };
+            var trees = CombineTrees(partialClass1, partialClass2);
 
             // Act
             var result = trees.MergePartials(new List<string> { "DEBUG", "UNITY_EDITOR" });
@@ -448,6 +438,14 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             Assert.That(structDeclarations.Count, Is.EqualTo(1), "Should have one struct declaration");
 
             yield return null;
+        }
+
+        private List<SyntaxTree> CombineTrees(params string[] files) {
+            return files.Select((it, i) => {
+                var path = Path.Combine(_tempPath, $"PartialClass{i}.cs");
+                File.WriteAllText(path, it);
+                return CSharpSyntaxTree.ParseText(it, path: path);
+            }).ToList();
         }
     }
 }

--- a/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
+++ b/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
@@ -139,6 +139,11 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
 
+            //Test Namespace
+            var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
+            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
+
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
             Assert.AreEqual("TestClass", classDeclaration.Identifier.Text, "Class name should be TestClass");
 
@@ -182,6 +187,11 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
 
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
+
+            //Test Namespace
+            var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
+            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
 
             var structDeclaration = root.DescendantNodes().OfType<StructDeclarationSyntax>().First();
             Assert.AreEqual("TestStruct", structDeclaration.Identifier.Text, "Struct name should be TestStruct");
@@ -256,6 +266,11 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
 
+            //Test Namespace
+            var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
+            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
+
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
             Assert.AreEqual("TestClassWithFields", classDeclaration.Identifier.Text, "Class name should be TestClassWithFields");
 
@@ -314,6 +329,11 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             // Assert
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
+
+            //Test Namespace
+            var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
+            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
 
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
             Assert.AreEqual("TestClass", classDeclaration.Identifier.Text, "Class name should be TestClass");

--- a/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
+++ b/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
@@ -86,15 +86,15 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
 
             // Assert
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
-            Assert.AreEqual("TestClass", classDeclaration.Identifier.Text, "Class name should be TestClass");
+            Assert.That("TestClass", Is.EqualTo(classDeclaration.Identifier.Text));
 
             // Test Fields
             var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
-            Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
+            Assert.That(fields.Count, Is.EqualTo(2));
 
             // Test Usings
             var usingDirectives = root.Usings;
-            Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
+            Assert.That(usingDirectives.Count, Is.EqualTo(2));
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
                 "Should have using System.Collections.Generic");
@@ -139,25 +139,25 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             // Assert
             // Test Namespace
             var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
-            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
-            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
+            Assert.That(namespaceDeclaration, Is.Not.Null);
+            Assert.That(namespaceDeclaration.Name.ToString(), Is.EqualTo("TestNamespace"));
 
             var structDeclaration = root.DescendantNodes().OfType<StructDeclarationSyntax>().First();
-            Assert.AreEqual("TestStruct", structDeclaration.Identifier.Text, "Struct name should be TestStruct");
+            Assert.That(structDeclaration.Identifier.Text, Is.EqualTo("TestStruct"));
 
             // Test Fields
             var fields = structDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
-            Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
+            Assert.That(fields.Count, Is.EqualTo(2));
 
             // Test Methods
             var methods = structDeclaration.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
-            Assert.AreEqual(2, methods.Count, "Combined class should have two methods");
+            Assert.That(methods.Count, Is.EqualTo(2));
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method1"), "Combined class should contain Method1");
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method2"), "Combined class should contain Method2");
 
             // Test Usings
             var usingDirectives = root.Usings;
-            Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
+            Assert.That(usingDirectives.Count, Is.EqualTo(2));
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
                 "Should have using System.Collections.Generic");
@@ -207,25 +207,25 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             // Assert
             // Test Namespace
             var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
-            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
-            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
+            Assert.That(namespaceDeclaration, Is.Not.Null);
+            Assert.That(namespaceDeclaration.Name.ToString(), Is.EqualTo("TestNamespace"));
 
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
-            Assert.AreEqual("TestClass", classDeclaration.Identifier.Text, "Class name should be TestClass");
+            Assert.That(classDeclaration.Identifier.Text, Is.EqualTo("TestClass"));
 
             // Test Fields
             var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
-            Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
+            Assert.That(fields.Count, Is.EqualTo(2));
 
             // Test Methods
             var methods = classDeclaration.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
-            Assert.AreEqual(2, methods.Count, "Combined class should have two methods");
+            Assert.That(methods.Count, Is.EqualTo(2));
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method1"), "Combined class should contain Method1");
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method2"), "Combined class should contain Method2");
 
             // Test Usings
             var usingDirectives = root.Usings;
-            Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
+            Assert.That(usingDirectives.Count, Is.EqualTo(2));
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
                 "Should have using System.Collections.Generic");
@@ -262,7 +262,7 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
 
             // Test Usings
             var usingDirectives = root.Usings;
-            Assert.AreEqual(1, usingDirectives.Count, "Should have one using directive");
+            Assert.That(usingDirectives.Count, Is.EqualTo(1));
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
 
             yield return null;
@@ -308,16 +308,15 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
 
             // Test Namespace
             var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
-            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
-            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
+            Assert.That(namespaceDeclaration, Is.Not.Null);
+            Assert.That(namespaceDeclaration.Name.ToString(), Is.EqualTo("TestNamespace"));
 
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
-            Assert.AreEqual("TestClassWithFields", classDeclaration.Identifier.Text,
-                "Class name should be TestClassWithFields");
+            Assert.That(classDeclaration.Identifier.Text, Is.EqualTo("TestClassWithFields"));
 
             // Test Fields
             var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
-            Assert.AreEqual(6, fields.Count, "Combined class should have six fields");
+            Assert.That(fields.Count, Is.EqualTo(6));
 
             // Test specific fields
             Assert.IsTrue(
@@ -349,7 +348,7 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
 
             // Test Usings
             var usingDirectives = root.Usings;
-            Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
+            Assert.That(usingDirectives.Count, Is.EqualTo(2));
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
                 "Should have using System.Collections.Generic");
@@ -390,15 +389,15 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
 
             // Test Namespace
             var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
-            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
-            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
+            Assert.That(namespaceDeclaration, Is.Not.Null);
+            Assert.That(namespaceDeclaration.Name.ToString(), Is.EqualTo("TestNamespace"));
 
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
-            Assert.AreEqual("TestClass", classDeclaration.Identifier.Text, "Class name should be TestClass");
+            Assert.That(classDeclaration.Identifier.Text, Is.EqualTo("TestClass"));
 
             // Test Fields
             var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
-            Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
+            Assert.That(fields.Count, Is.EqualTo(2));
             Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "_field1")),
                 "Should have _field1");
             Assert.IsTrue(fields.Any(f => f.Declaration.Variables.Any(v => v.Identifier.Text == "_field2")),
@@ -406,20 +405,20 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
 
             // Test Methods
             var methods = classDeclaration.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
-            Assert.AreEqual(2, methods.Count, "Combined class should have two methods");
+            Assert.That(methods.Count, Is.EqualTo(2));
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method1"), "Combined class should contain Method1");
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method2"), "Combined class should contain Method2");
 
             // Test Usings
             var usingDirectives = root.Usings;
-            Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
+            Assert.That(usingDirectives.Count, Is.EqualTo(2));
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System.Collections.Generic"),
                 "Should have using System.Collections.Generic");
 
             // Test that there's only one class declaration
             var classDeclarations = root.DescendantNodes().OfType<ClassDeclarationSyntax>().ToList();
-            Assert.AreEqual(1, classDeclarations.Count, "Should only have one class declaration after merging");
+            Assert.That(classDeclarations.Count, Is.EqualTo(1));
 
             yield return null;
         }
@@ -468,10 +467,10 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             var root = combinedTree.GetCompilationUnitRoot();
 
             var classDeclarations = root.DescendantNodes().OfType<ClassDeclarationSyntax>().ToList();
-            Assert.That(classDeclarations.Count, Is.EqualTo(2), "Should have two class declarations");
+            Assert.That(classDeclarations.Count, Is.EqualTo(2));
 
             var structDeclarations = root.DescendantNodes().OfType<StructDeclarationSyntax>().ToList();
-            Assert.That(structDeclarations.Count, Is.EqualTo(1), "Should have one struct declaration");
+            Assert.That(structDeclarations.Count, Is.EqualTo(1));
 
             yield return null;
         }
@@ -505,7 +504,7 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
 
             // Test Usings
             var usingDirectives = root.Usings;
-            Assert.AreEqual(2, usingDirectives.Count, "Should have two using directives");
+            Assert.That(usingDirectives.Count, Is.EqualTo(2));
             Assert.IsTrue(usingDirectives.Any(u => u.Name!.ToString() == "System"), "Should have using System");
             Assert.IsTrue(usingDirectives.Any(u =>
                     u.Alias != null && u.Alias.Name.ToString() == "StringList" &&

--- a/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
+++ b/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
@@ -58,6 +58,28 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             yield return MergeAndTest_CSharpPartialClass(partialClass1, partialClass2);
         }
 
+        [UnityTest]
+        public IEnumerator Partials_ClassMergeWithoutNamespaceTest()
+        {
+            const string partialClass1 = @"
+            using System;
+            public partial class TestClass
+            {
+                private int _field1;
+                public void Method1() { }
+            }";
+
+            const string partialClass2 = @"
+            using System.Collections.Generic;
+            public partial class TestClass
+            {
+                private int _field2;
+                public void Method2() { }
+            }";
+
+            yield return MergeAndTest_CSharpPartialClass(partialClass1, partialClass2, hasNamespace: false);
+        }
+
 
         [UnityTest]
         public IEnumerator Partials_StructMergeTest()
@@ -117,7 +139,8 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             yield return MergeAndTest_CSharpPartialClass(partialClass1, partialClass2);
         }
 
-        private IEnumerator MergeAndTest_CSharpPartialClass(string partialClass1, string partialClass2)
+        private IEnumerator MergeAndTest_CSharpPartialClass(string partialClass1, string partialClass2,
+            bool hasNamespace = true)
         {
             var path1 = Path.Combine(_tempPath, "PartialClass1.cs");
             var path2 = Path.Combine(_tempPath, "PartialClass2.cs");
@@ -139,10 +162,12 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
 
-            //Test Namespace
-            var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
-            Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
-            Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
+            if (hasNamespace) {
+                //Test Namespace
+                var namespaceDeclaration = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+                Assert.IsNotNull(namespaceDeclaration, "Namespace should exist");
+                Assert.AreEqual("TestNamespace", namespaceDeclaration.Name.ToString(), "Namespace should be TestNamespace");
+            }
 
             var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
             Assert.AreEqual("TestClass", classDeclaration.Identifier.Text, "Class name should be TestClass");

--- a/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
+++ b/Assets/Tests/Editor/Integration/CodePatterns/MergePartialClassesTest.cs
@@ -139,15 +139,15 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
 
-            var classDeclaration = root.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax>().First();
+            var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
             Assert.AreEqual("TestClass", classDeclaration.Identifier.Text, "Class name should be TestClass");
 
             //Test Fields
-            var fields = classDeclaration.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.FieldDeclarationSyntax>().ToList();
+            var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
             Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
 
             //Test Methods
-            var methods = classDeclaration.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax>().ToList();
+            var methods = classDeclaration.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
             Assert.AreEqual(2, methods.Count, "Combined class should have two methods");
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method1"), "Combined class should contain Method1");
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method2"), "Combined class should contain Method2");
@@ -183,15 +183,15 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
 
-            var structDeclaration = root.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.StructDeclarationSyntax>().First();
+            var structDeclaration = root.DescendantNodes().OfType<StructDeclarationSyntax>().First();
             Assert.AreEqual("TestStruct", structDeclaration.Identifier.Text, "Struct name should be TestStruct");
 
             //Test Fields
-            var fields = structDeclaration.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.FieldDeclarationSyntax>().ToList();
+            var fields = structDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
             Assert.AreEqual(2, fields.Count, "Combined class should have two fields");
 
             //Test Methods
-            var methods = structDeclaration.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax>().ToList();
+            var methods = structDeclaration.DescendantNodes().OfType<MethodDeclarationSyntax>().ToList();
             Assert.AreEqual(2, methods.Count, "Combined class should have two methods");
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method1"), "Combined class should contain Method1");
             Assert.IsTrue(methods.Any(m => m.Identifier.Text == "Method2"), "Combined class should contain Method2");
@@ -256,11 +256,11 @@ namespace FastScriptReload.Tests.Editor.Integration.CodePatterns
             var combinedTree = result.First();
             var root = combinedTree.GetCompilationUnitRoot();
 
-            var classDeclaration = root.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.ClassDeclarationSyntax>().First();
+            var classDeclaration = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
             Assert.AreEqual("TestClassWithFields", classDeclaration.Identifier.Text, "Class name should be TestClassWithFields");
 
             // Test Fields
-            var fields = classDeclaration.DescendantNodes().OfType<Microsoft.CodeAnalysis.CSharp.Syntax.FieldDeclarationSyntax>().ToList();
+            var fields = classDeclaration.DescendantNodes().OfType<FieldDeclarationSyntax>().ToList();
             Assert.AreEqual(6, fields.Count, "Combined class should have six fields");
 
             // Test specific fields


### PR DESCRIPTION
I got tired of waiting and fixed #137 myself 😅
Also included fix for tests - all of them are now green on my machine too.
And small performance improvement.
Found another bug and fixed it - partial type inner types were duplicated on namespace level (there was correct inner type inside partial type and the same was duplicated on namespace level and resulting file wouldn't compile).
And another bug and fixed it - using directives were duplicated in merged partial classes.