### PR TITLE
Update AssemblyChangesLoader.cs

### DIFF
--- a/Assets/Scripts/Runtime/AssemblyChangesLoader.cs
+++ b/Assets/Scripts/Runtime/AssemblyChangesLoader.cs
@@ -221,11 +221,14 @@ namespace FastScriptReload.Runtime
                     LoggerScoped.LogWarning($"Type: {originalType.Name} is not {nameof(MonoBehaviour)}, {ON_HOT_RELOAD_METHOD_NAME} method can't be executed. You can still use static version: {ON_HOT_RELOAD_NO_INSTANCE_STATIC_METHOD_NAME}");
                     return;
                 }
-                 //TODO: perf - could find them in different way?
-                 foreach (var instanceOfType in Object.FindObjectsByType(originalType, FindObjectsSortMode.None)) // changed from obsolete GameObject.FindObjectsOfType(originalType))
-                {
+                       //TODO: perf - could find them in different way?
+#if UNITY_6000_0_OR_NEWER // added new FindObjectsByType
+                foreach (var instanceOfType in Object.FindObjectsByType(originalType, FindObjectsSortMode.None))
                     onScriptHotReloadFn.Invoke(instanceOfType, null);
-                }
+#elif UNITY_2021_1_OR_NEWER // keeping FindObjectOfType for older unity versions
+                foreach (var instanceOfType in Object.FindObjectsOfType(originalType))
+                    onScriptHotReloadFn.Invoke(instanceOfType, null);
+#endif
             });
         }
 

--- a/Assets/Scripts/Runtime/AssemblyChangesLoader.cs
+++ b/Assets/Scripts/Runtime/AssemblyChangesLoader.cs
@@ -221,8 +221,8 @@ namespace FastScriptReload.Runtime
                     LoggerScoped.LogWarning($"Type: {originalType.Name} is not {nameof(MonoBehaviour)}, {ON_HOT_RELOAD_METHOD_NAME} method can't be executed. You can still use static version: {ON_HOT_RELOAD_NO_INSTANCE_STATIC_METHOD_NAME}");
                     return;
                 }
-
-                foreach (var instanceOfType in GameObject.FindObjectsOfType(originalType)) //TODO: perf - could find them in different way?
+                 //TODO: perf - could find them in different way?
+                 foreach (var instanceOfType in Object.FindObjectsByType(originalType, FindObjectsSortMode.None)) // changed from obsolete GameObject.FindObjectsOfType(originalType))
                 {
                     onScriptHotReloadFn.Invoke(instanceOfType, null);
                 }


### PR DESCRIPTION
 // changed from obsolete GameObject.FindObjectsOfType(originalType))
in unity6 (and maybe older versions "GameObject.FindObjectsOfType(originalType))" is obsolete and less performant (according to unity docs) than then newer "Object.FindObjectsByType"

(p.s! this is my very first pull request so i dont know if this is correctly done )

![image](https://github.com/user-attachments/assets/40e1e9e0-329e-429e-b270-433cd42cd779)
![image](https://github.com/user-attachments/assets/c736d8f7-8e74-484b-9c71-8759b5d4393a)
![image](https://github.com/user-attachments/assets/cf6eb87b-7725-47d3-ab91-49040650a9a4)
