### PR TITLE
Support File-Scoped Namespaces in Syntax Processing

### DIFF
--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/SyntaxTreeHelpers.cs
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/Partials/SyntaxTreeHelpers.cs
@@ -13,7 +13,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
             var currentNode = typeDeclaration.Parent;
             while (currentNode != null)
             {
-                if (currentNode is NamespaceDeclarationSyntax namespaceDeclaration)
+                if (currentNode is BaseNamespaceDeclarationSyntax namespaceDeclaration)
                 {
                     namespaces.Add(namespaceDeclaration.Name.ToString());
                 }

--- a/Assets/Scripts/Editor/Compilation/CodeRewriting/RoslynUtils.cs
+++ b/Assets/Scripts/Editor/Compilation/CodeRewriting/RoslynUtils.cs
@@ -19,7 +19,7 @@ namespace FastScriptReload.Editor.Compilation.CodeRewriting
             var fullTypeContibutingAncestorNames = memberNode.Ancestors().OfType<MemberDeclarationSyntax>().Select(da =>
             {
                 if (da is TypeDeclarationSyntax t) return t.Identifier.ToString();
-                else if (da is NamespaceDeclarationSyntax n) return n.Name.ToString();
+                else if (da is BaseNamespaceDeclarationSyntax n) return n.Name.ToString();
                 else throw new Exception("Unable to resolve full field name");
             }).Reverse().ToList();
 

--- a/Assets/Scripts/Editor/Compilation/DynamicCompilationBase.cs
+++ b/Assets/Scripts/Editor/Compilation/DynamicCompilationBase.cs
@@ -250,7 +250,7 @@ namespace FastScriptReload.Editor.Compilation
                     .ToList();
 
                 //types should be added either to root namespace or root of document
-                var rootNamespace = root.DescendantNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+                var rootNamespace = root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault();
                 foreach (var overridenTypeToAdd in userDefinedOverrideTypesWithoutMatchnigInRecompiledFile)
                 {
                     var newMember = FastScriptReloadCodeRewriterBase.AddRewriteCommentIfNeeded(overridenTypeToAdd.Value,
@@ -260,7 +260,7 @@ namespace FastScriptReload.Editor.Compilation
                     if (rootNamespace != null)
                     {
                         rootNamespace =
-                            root.DescendantNodes().OfType<NamespaceDeclarationSyntax>()
+                            root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>()
                                 .FirstOrDefault(); //need to search again to make sure it didn't change
                         var newRootNamespace = rootNamespace.AddMembers(newMember);
                         root = root.ReplaceNode(rootNamespace, newRootNamespace);


### PR DESCRIPTION
This PR updates the syntax processing to support file-scoped namespaces introduced in C# 10 by replacing usages of `NamespaceDeclarationSyntax` with the more general `BaseNamespaceDeclarationSyntax`.

## Changes

- Replaced `NamespaceDeclarationSyntax` with `BaseNamespaceDeclarationSyntax` in:
  - `SyntaxTreeHelpers.cs`
  - `RoslynUtils.cs`
  - `DynamicCompilationBase.cs`

- Ensures compatibility with both:
  - Block-scoped namespaces:
    ```csharp
    namespace MyNamespace { ... }
    ```
  - File-scoped namespaces:
    ```csharp
    namespace MyNamespace;
    ```

## Notes

To enable file-scoped namespaces:

- Add a `csc.rsp` file to the `Assets` root containing:

    ```
    langVersion:preview
    ```

- And add a `Directory.Build.props` file with:

    ```xml
    <Project>
        <PropertyGroup>
            <LangVersion>11.0</LangVersion>
        </PropertyGroup>
    </Project>
    ```