### PR TITLE
6.5 Fixes

### DIFF
--- a/Assets/Scripts/Editor/FastScriptReloadManager.cs
+++ b/Assets/Scripts/Editor/FastScriptReloadManager.cs
@@ -456,7 +456,11 @@ namespace FastScriptReload.Editor
         
         private static string ResolveRelativeToAssetDirectoryFilePath(UnityEngine.Object obj)
         {
+#if UNITY_6000_5_OR_NEWER
             return AssetDatabase.GetAssetPath(obj.GetEntityId());
+#else
+            return AssetDatabase.GetAssetPath(obj.GetInstanceID());
+#endif
         }
 
         public void Update()

--- a/Assets/Scripts/Editor/FastScriptReloadManager.cs
+++ b/Assets/Scripts/Editor/FastScriptReloadManager.cs
@@ -456,7 +456,7 @@ namespace FastScriptReload.Editor
         
         private static string ResolveRelativeToAssetDirectoryFilePath(UnityEngine.Object obj)
         {
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             return AssetDatabase.GetAssetPath(obj.GetEntityId());
 #else
             return AssetDatabase.GetAssetPath(obj.GetInstanceID());

--- a/Assets/Scripts/Editor/FastScriptReloadManager.cs
+++ b/Assets/Scripts/Editor/FastScriptReloadManager.cs
@@ -456,7 +456,7 @@ namespace FastScriptReload.Editor
         
         private static string ResolveRelativeToAssetDirectoryFilePath(UnityEngine.Object obj)
         {
-            return AssetDatabase.GetAssetPath(obj.GetInstanceID());
+            return AssetDatabase.GetAssetPath(obj.GetEntityId());
         }
 
         public void Update()


### PR DESCRIPTION
I am also getting the following:
```
/home/nn/Data/Projects/Unity/Katana/Modules/UnityFastScriptReload/Assets/Scripts/Editor/FileWatcherSetupEntry.cs(8,18): warning UAC1002: Type 'FastScriptReload.Editor.FileWatcherSetupEntry' is in a serialization hierarchy but 'ImmersiveVRTools.Editor.Common.WelcomeScreen.PreferenceDefinition.JsonObjectListSerializable<FastScriptReload.Editor.FileWatcherSetupEntry>' in the hierarchy lacks [Serializable]; all classes in the hierarchy must be marked
```
Although idk if  that's related to 6.5, I could look into it if you'd like.