### PR TITLE
Replaced GetInstanceID() with GetEntityId() for Unity 6.4 API changes

### DIFF
--- a/Assets/Scripts/Editor/FastScriptReloadManager.cs
+++ b/Assets/Scripts/Editor/FastScriptReloadManager.cs
@@ -456,7 +456,11 @@ namespace FastScriptReload.Editor
         
         private static string ResolveRelativeToAssetDirectoryFilePath(UnityEngine.Object obj)
         {
+#if UNITY_6000_4_OR_NEWER
+            return AssetDatabase.GetAssetPath(obj.GetEntityId());
+#else
             return AssetDatabase.GetAssetPath(obj.GetInstanceID());
+#endif
         }
 
         public void Update()


### PR DESCRIPTION
This makes FastScriptReload compile without errors in Unity 6.5, and addresses obsolete warnings in Unity 6.4.
Before this PR, you would get the 2 following errors preventing you from entering play mode/building.

<details>

<summary>Errors</summary>

```
/home/nn/Data/Projects/Unity/Katana/Modules/UnityFastScriptReload/Assets/Scripts/Editor/FastScriptReloadManager.cs(459,20): error CS0619: 'AssetDatabase.GetAssetPath(int)' is obsolete: 'Please use GetAssetPath(EntityId) with the EntityId parameter type instead.'
```
```
/home/nn/Data/Projects/Unity/Katana/Modules/UnityFastScriptReload/Assets/Scripts/Editor/FastScriptReloadManager.cs(459,47): error CS0619: 'Object.GetInstanceID()' is obsolete: 'GetInstanceID is deprecated. Use GetEntityId instead. This will be removed in a future version.'
```

</details>

There is still 1 more warning that I am guessing was introduced in Unity 6.5 as I've seen it in other assets I contributed to, but I decided not to address it in this PR as it doesn't cause any actual issues from what I could tell.

<details>

<summary>Warning</summary>

```
HierarchyDecorator components updated due to changes detected.
UnityEngine.Debug:LogWarning (object)
HierarchyDecorator.ComponentData:UpdateData (bool) (at /home/nn/Data/Projects/Unity/Katana/Modules/UnityHierarchyDecorator/HierarchyDecorator/Scripts/Editor/Data/ComponentData.cs:220)
HierarchyDecorator.Settings:OnAfterDeserialize () (at /home/nn/Data/Projects/Unity/Katana/Modules/UnityHierarchyDecorator/HierarchyDecorator/Scripts/Editor/Settings.cs:53)
UnityEditor.AssetDatabase:LoadAssetAtPath<HierarchyDecorator.Settings> (string)
HierarchyDecorator.HierarchyDecorator:TryLoadSettings (HierarchyDecorator.Settings&) (at /home/nn/Data/Projects/Unity/Katana/Modules/UnityHierarchyDecorator/HierarchyDecorator/Scripts/Editor/HierarchyDecorator.cs:81)
HierarchyDecorator.HierarchyDecorator:GetOrCreateSettings () (at /home/nn/Data/Projects/Unity/Katana/Modules/UnityHierarchyDecorator/HierarchyDecorator/Scripts/Editor/HierarchyDecorator.cs:63)
HierarchyDecorator.HierarchyDecorator:get_Settings () (at /home/nn/Data/Projects/Unity/Katana/Modules/UnityHierarchyDecorator/HierarchyDecorator/Scripts/Editor/HierarchyDecorator.cs:24)
HierarchyDecorator.HierarchyManager:get_s_Settings () (at /home/nn/Data/Projects/Unity/Katana/Modules/UnityHierarchyDecorator/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs:23)
HierarchyDecorator.HierarchyManager:DrawSceneItemHighlight (UnityEngine.Rect,UnityEngine.EntityId) (at /home/nn/Data/Projects/Unity/Katana/Modules/UnityHierarchyDecorator/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs:201)
HierarchyDecorator.HierarchyManager:OnGUI (UnityEngine.EntityId,UnityEngine.Rect) (at /home/nn/Data/Projects/Unity/Katana/Modules/UnityHierarchyDecorator/HierarchyDecorator/Scripts/Editor/HierarchyManager.cs:112)
UnityEditor.GUIView:ProcessEvent (UnityEngine.EntityId,intptr,bool&) (at /home/bokken/build/output/unity/unity/Editor/Mono/GUIView.cs:70)
```

</details>

On top of that, I want to make it perfectly clear that this PR doesn't address any other issues FSR might have when used in Unity 6.5, and from my limited testing, it didn't exactly work great(although it could be something on my end, I am genuinely not sure).
It just aims to replace obsolete/deprecated API so FSR can compile in newer editor versions.